### PR TITLE
Fixed stack overflow bug

### DIFF
--- a/src/CollectBlock.ts
+++ b/src/CollectBlock.ts
@@ -44,9 +44,9 @@ function collectAll (bot: Bot, options: CollectOptionsFull, cb: Callback): void 
         }
 
         if (closest.constructor.name === 'Block') {
-          collectBlock(bot, closest as Block, options, collectNext)
+          collectBlock(bot, closest as Block, options, () => setTimeout(collectNext, 0))
         } else if (closest.constructor.name === 'Entity') {
-          collectItem(bot, closest as Entity, options, collectNext)
+          collectItem(bot, closest as Entity, options, () => setTimeout(collectNext, 0))
         } else {
           cb(error('UnknownType', `Target ${closest.constructor.name} is not a Block or Entity!`))
         }


### PR DESCRIPTION
Sometimes, when dealing with very large collection lists with entries that return instantly, (such as invalid entities or destroyed blocks, the plugin would throw a stack overflow after a short period of time. This small tweak fixes that.