### PR TITLE
Properly clean up events

### DIFF
--- a/src/CollectBlock.ts
+++ b/src/CollectBlock.ts
@@ -52,6 +52,7 @@ function collectAll (bot: Bot, options: CollectOptionsFull, cb: Callback): void 
         }
       })
     } else {
+      tempEvents.cleanup()
       cb()
     }
   }


### PR DESCRIPTION
This fixes the error
```(node:5764) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 entityGone listeners added to [Bot]. Use emitter.setMaxListeners() to increase limit```

Happening when calling `collectBlock.collect()` again in its callback