### PR TITLE
Add missing end quote and comma to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The brief description goes here.
 // Create your bot
 const mineflayer = require("mineflayer")
 const bot = mineflayer.createBot({
-  host: 'localhost
+  host: 'localhost',
   username: 'Player',
 })
 let mcData


### PR DESCRIPTION
There was a minor syntax error in the example. This PR aims to fix it.