### PR TITLE
Swap chest goal from GoalBlock to GoalGetToBlock

### DIFF
--- a/src/Inventory.ts
+++ b/src/Inventory.ts
@@ -87,7 +87,7 @@ function gotoChest (bot: Bot, location: Vec3, cb: Callback): void {
   // @ts-expect-error
   const pathfinder = bot.pathfinder
 
-  pathfinder.setGoal(new goals.GoalBlock(location.x, location.y, location.z))
+  pathfinder.setGoal(new goals.GoalGetToBlock(location.x, location.y, location.z))
 
   const events = new TemporarySubscriber(bot)
   events.subscribeTo('goal_reached', () => {


### PR DESCRIPTION
[GoalBlock](https://github.com/PrismarineJS/mineflayer-pathfinder/blob/1b8b3d70ea40b888d36a74954f72b25ab9dedbcb/lib/goals.js#L24) aims to place the bot in the given location. Using [GoalGetToBlock](https://github.com/PrismarineJS/mineflayer-pathfinder/blob/1b8b3d70ea40b888d36a74954f72b25ab9dedbcb/lib/goals.js#L106) will allow the bot to approach the chest, end the goal when near, then interact with it.