### PR TITLE
Bump min Pathfinder version to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/TheDudeFromCI/mineflayer-collectblock#readme",
   "dependencies": {
     "mineflayer": "^4.0.0",
-    "mineflayer-pathfinder": "^2.0.0",
+    "mineflayer-pathfinder": "^2.1.0",
     "mineflayer-tool": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/TheDudeFromCI/mineflayer-collectblock#readme",
   "dependencies": {
     "mineflayer": "^4.0.0",
-    "mineflayer-pathfinder": "^2.1.0",
+    "mineflayer-pathfinder": "^2.1.1",
     "mineflayer-tool": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Pathfinder version 2.0.0 fails to compile due to version conflicts with Minecraft data, however this is fixed in 2.1.0. min package version should be bumped to reflect this.