### PR TITLE
fix: add declaration for mineflayer plugin in index.ts

### DIFF
--- a/src/CollectBlock.ts
+++ b/src/CollectBlock.ts
@@ -9,7 +9,6 @@ import { emptyInventoryIfFull, ItemFilter } from './Inventory'
 import { findFromVein } from './BlockVeins'
 import { Collectable, Targets } from './Targets'
 import { Item } from 'prismarine-item'
-import mcDataLoader from 'minecraft-data'
 import { once } from 'events'
 import { callbackify } from 'util'
 
@@ -198,7 +197,7 @@ export class CollectBlock {
   constructor (bot: Bot) {
     this.bot = bot
     this.targets = new Targets(bot)
-    this.movements = new Movements(bot, mcDataLoader(bot.version))
+    this.movements = new Movements(bot)
   }
 
   /**

--- a/src/Inventory.ts
+++ b/src/Inventory.ts
@@ -77,7 +77,6 @@ async function placeItems (bot: Bot, chestPos: Vec3, itemFilter: ItemFilter, cb?
   const chest = await bot.openChest(chestBlock)
   for (const item of bot.inventory.items()) {
     if (!itemFilter(item)) continue
-    // @ts-expect-error; A workaround for checking if the chest is already full
     if (chest.firstEmptyContainerSlot() === null) {
       // We have items that didn't fit.
       return true

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { plugin as toolPlugin } from 'mineflayer-tool'
 
 declare module 'mineflayer' {
   interface Bot {
-    collectBlock: CollectBlock;
+    collectBlock: CollectBlock
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,13 @@ import { CollectBlock } from './CollectBlock'
 import { pathfinder as pathfinderPlugin } from 'mineflayer-pathfinder'
 import { plugin as toolPlugin } from 'mineflayer-tool'
 
+declare module 'mineflayer' {
+  interface Bot {
+    collectBlock: CollectBlock;
+  }
+}
+
 export function plugin (bot: Bot): void {
-  // @ts-expect-error
   bot.collectBlock = new CollectBlock(bot)
 
   // Load plugins if not loaded manually.


### PR DESCRIPTION
Right now, when you try to use `bot.collectBlock` in TypeScript, it doesn't know that the `Bot` can do that and errors. This adds a mineflayer module declaration, similar to https://github.com/PrismarineJS/mineflayer-pathfinder ([here](https://github.com/PrismarineJS/mineflayer-pathfinder/blob/fc25bfca8911df48ac0124bcf4d1d26e07e6d594/index.d.ts#L373-L389)). I also removed the unneeded ts-expect-error since TypeScript now knows that there's a `CollectBlock` supposed to be there.