### PR TITLE
Fix collect blocks that require tools

### DIFF
--- a/src/CollectBlock.ts
+++ b/src/CollectBlock.ts
@@ -68,7 +68,7 @@ async function mineBlock (bot: Bot, block: Block, options: CollectOptionsFull): 
   await bot.tool.equipForBlock(block, equipToolOptions)
 
   // @ts-expect-error
-  if (!block.canHarvest(bot.heldItem)) {
+  if (!block.canHarvest(bot.heldItem.type)) {
     options.targets.removeTarget(block)
     return
   }

--- a/src/CollectBlock.ts
+++ b/src/CollectBlock.ts
@@ -67,8 +67,7 @@ async function mineBlock (bot: Bot, block: Block, options: CollectOptionsFull): 
 
   await bot.tool.equipForBlock(block, equipToolOptions)
 
-  // @ts-expect-error
-  if (!block.canHarvest(bot.heldItem.type)) {
+  if (bot.heldItem !== null && !block.canHarvest(bot.heldItem.type)) {
     options.targets.removeTarget(block)
     return
   }


### PR DESCRIPTION
Currently the bot will not collect blocks that require tools (stone, obsidian, etc) even when it has the correct tools. This was because the canHarvest check was being given the equipped item object instead of the id. This has been fixed. I was using this to test:
```
const mineflayer = require("mineflayer")
const bot = mineflayer.createBot({
  host: 'localhost',
  username: 'Player',
})

// Load collect block
bot.loadPlugin(require('mineflayer-collectblock').plugin)

// Listen for when a player says "collect [something]" in chat
bot.on('chat', async (username, message) => {
    const args = message.split(' ')
    if (args[0] !== 'collect') return
  
    // Get the correct block type
    const blockType = bot.registry.blocksByName[args[1]]
    if (!blockType) {
      bot.chat("I don't know any blocks with that name.")
      return
    }
  
    bot.chat('Collecting the nearest ' + blockType.name)
  
    // Try and find that block type in the world
    const block = bot.findBlock({
      matching: blockType.id,
      maxDistance: 64
    })
  
    if (!block) {
      bot.chat("I don't see that block nearby.")
      return
    }
  
    // Collect the block if we found one
    await bot.collectBlock.collect(block);
    bot.chat('Done.')
  })
```
To test, give the bot a pickaxe and ask it to `collect stone`.
I think this fixes #129 