### PR TITLE
Update CollectBlock.ts

### DIFF
--- a/src/CollectBlock.ts
+++ b/src/CollectBlock.ts
@@ -238,8 +238,8 @@ export class CollectBlock {
     }
 
     if (this.movements != null) {
-      this.movements.dontMineUnderFallingBlock = false;
-      this.movements.dontCreateFlow = false;
+      this.movements.dontMineUnderFallingBlock = false
+      this.movements.dontCreateFlow = false
       this.bot.pathfinder.setMovements(this.movements)
     }
 

--- a/src/CollectBlock.ts
+++ b/src/CollectBlock.ts
@@ -238,6 +238,8 @@ export class CollectBlock {
     }
 
     if (this.movements != null) {
+      this.movements.dontMineUnderFallingBlock = false;
+      this.movements.dontCreateFlow = false;
       this.bot.pathfinder.setMovements(this.movements)
     }
 


### PR DESCRIPTION
Fix: disable movement restrictions for falling blocks and water flow

This allows the bot to mine blocks that might cause water flow or falling blocks, which is often necessary when mining ores or other materials that might be under sand/gravel or near water sources.